### PR TITLE
Make failable functions return options

### DIFF
--- a/weechat-rs/src/buffer.rs
+++ b/weechat-rs/src/buffer.rs
@@ -219,15 +219,15 @@ impl Nick {
         let weechat = self.get_weechat();
         let get_string = weechat.get().nicklist_nick_get_string.unwrap();
         let c_property = CString::new(property).unwrap();
-        let value = unsafe {
+        unsafe {
             let ret = get_string(self.buf_ptr, self.ptr, c_property.as_ptr());
 
             if ret.is_null() {
                 None
             } else {
-                CStr::from_ptr(ret).to_str().unwrap_or_default()
+                Some(CStr::from_ptr(ret).to_str().unwrap_or_default())
             }
-        };
+        }
     }
 
     /// Get the name property of the nick.

--- a/weechat-rs/src/infolist.rs
+++ b/weechat-rs/src/infolist.rs
@@ -77,15 +77,15 @@ impl Infolist {
     /// The types are: "i" (integer), "s" (string), "p" (pointer), "b" (buffer),
     /// "t" (time).
     /// Example: "i:my_integer,s:my_string"
-    pub fn fields(&self) -> &str {
+    pub fn fields(&self) -> Option<&str> {
         let weechat = Weechat::from_ptr(self.weechat_ptr);
         let infolist_fields = weechat.get().infolist_fields.unwrap();
         unsafe {
             let ret = infolist_fields(self.ptr);
             if ret.is_null() {
-                ""
+                None
             } else {
-                CStr::from_ptr(ret).to_str().unwrap_or_default()
+                Some(CStr::from_ptr(ret).to_str().unwrap_or_default())
             }
         }
     }
@@ -113,8 +113,7 @@ impl Infolist {
 
     /// Get the value of a string variable in the current infolist item.
     /// * `name` - The variable name of the infolist item.
-    /// If the variable isn't found an empty string is returned.
-    pub fn get_string(&self, name: &str) -> &str {
+    pub fn get_string(&self, name: &str) -> Option<&str> {
         let weechat = Weechat::from_ptr(self.weechat_ptr);
         let infolist_string = weechat.get().infolist_string.unwrap();
 
@@ -123,9 +122,9 @@ impl Infolist {
         unsafe {
             let ret = infolist_string(self.ptr, name.as_ptr());
             if ret.is_null() {
-                ""
+                None
             } else {
-                CStr::from_ptr(ret).to_str().unwrap_or_default()
+                Some(CStr::from_ptr(ret).to_str().unwrap_or_default())
             }
         }
     }

--- a/weechat-rs/src/weechat.rs
+++ b/weechat-rs/src/weechat.rs
@@ -122,7 +122,7 @@ impl Weechat {
     /// Get some info from Weechat or a plugin.
     /// * `info_name` - name the info
     /// * `arguments` - arguments for the info
-    pub fn info_get(&self, info_name: &str, arguments: &str) -> &str {
+    pub fn info_get(&self, info_name: &str, arguments: &str) -> Option<&str> {
         let info_get = self.get().info_get.unwrap();
 
         let info_name = CString::new(info_name).unwrap_or_default();
@@ -135,9 +135,9 @@ impl Weechat {
                 arguments.as_ptr()
             );
             if info.is_null() {
-                ""
+                None
             } else {
-                CStr::from_ptr(info).to_str().unwrap_or_default()
+                Some(CStr::from_ptr(info).to_str().unwrap_or_default())
             }
         }
     }


### PR DESCRIPTION
This makes all failable functions return Options instead of returning an empty string.