### PR TITLE
Lossy strings

### DIFF
--- a/sample/src/lib.rs
+++ b/sample/src/lib.rs
@@ -1,4 +1,5 @@
 use std::time::Instant;
+use std::borrow::Cow;
 use weechat::{
     weechat_plugin, ArgsWeechat, Buffer, CommandDescription, CommandHook,
     Config, ConfigOption, ConfigSectionInfo, NickArgs, StringOption, Weechat,
@@ -12,7 +13,7 @@ struct SamplePlugin {
 }
 
 impl SamplePlugin {
-    fn input_cb(data: &mut String, buffer: Buffer, _input: &str) {
+    fn input_cb(data: &mut String, buffer: Buffer, _input: Cow<str>) {
         buffer.print(data);
         if data == "Hello" {
             data.push_str(" world.");

--- a/weechat-rs/src/config.rs
+++ b/weechat-rs/src/config.rs
@@ -12,7 +12,7 @@ use crate::config_options::{
     ConfigOption, IntegerOption, OptionDescription, OptionPointers, OptionType,
     StringOption,
 };
-use crate::Weechat;
+use crate::{LossyCString, Weechat};
 use weechat_sys::{
     t_config_file, t_config_option, t_config_section, t_weechat_plugin,
     WEECHAT_RC_ERROR, WEECHAT_RC_OK,
@@ -112,7 +112,7 @@ impl<T> Config<T> {
 
         let new_section = weechat.get().config_new_section.unwrap();
 
-        let name = CString::new(section_info.name).unwrap_or_default();
+        let name = LossyCString::new(section_info.name);
 
         let ptr = unsafe {
             new_section(
@@ -325,15 +325,13 @@ impl ConfigSection {
 
         let weechat = Weechat::from_ptr(self.weechat_ptr);
 
-        let name = CString::new(option_description.name).unwrap();
-        let description = CString::new(option_description.description).unwrap();
+        let name = LossyCString::new(option_description.name);
+        let description = LossyCString::new(option_description.description);
         let option_type =
             CString::new(option_description.option_type.as_str()).unwrap();
-        let string_values =
-            CString::new(option_description.string_values).unwrap();
-        let default_value =
-            CString::new(option_description.default_value).unwrap();
-        let value = CString::new(option_description.value).unwrap();
+        let string_values = LossyCString::new(option_description.string_values);
+        let default_value = LossyCString::new(option_description.default_value);
+        let value = LossyCString::new(option_description.value);
 
         let option_pointers = Box::new(OptionPointers::<T, A, B, C> {
             weechat_ptr: self.weechat_ptr,
@@ -431,7 +429,7 @@ impl Weechat {
             WEECHAT_RC_OK
         }
 
-        let c_name = CString::new(name).unwrap();
+        let c_name = LossyCString::new(name);
 
         let config_pointers = Box::new(ConfigPointers::<T> {
             reload_cb: reload_callback,

--- a/weechat-rs/src/config_options.rs
+++ b/weechat-rs/src/config_options.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs)]
 
 use crate::Weechat;
+use std::borrow::Cow;
 use weechat_sys::{t_config_option, t_weechat_plugin};
 
 #[derive(Default)]
@@ -60,7 +61,7 @@ pub trait ConfigOption {
 
 pub(crate) struct OptionPointers<T, A, B, C> {
     pub(crate) weechat_ptr: *mut t_weechat_plugin,
-    pub(crate) check_cb: Option<fn(&mut A, &T, &str)>,
+    pub(crate) check_cb: Option<fn(&mut A, &T, Cow<str>)>,
     pub(crate) check_cb_data: A,
     pub(crate) change_cb: Option<fn(&mut B, &T)>,
     pub(crate) change_cb_data: B,

--- a/weechat-rs/src/hooks.rs
+++ b/weechat-rs/src/hooks.rs
@@ -6,14 +6,13 @@
 //! This module contains hook creation methods for the `Weechat` object.
 
 use libc::{c_char, c_int};
-use std::ffi::CString;
 use std::os::raw::c_void;
 use std::os::unix::io::AsRawFd;
 use std::ptr;
 
 use weechat_sys::{t_gui_buffer, t_hook, t_weechat_plugin, WEECHAT_RC_OK};
 
-use crate::{ArgsWeechat, Buffer, Weechat};
+use crate::{ArgsWeechat, Buffer, LossyCString, Weechat};
 
 /// Weechat Hook type. The hook is unhooked automatically when the object is
 /// dropped.
@@ -131,12 +130,11 @@ impl Weechat {
             WEECHAT_RC_OK
         }
 
-        let name = CString::new(command_info.name).unwrap();
-        let description = CString::new(command_info.description).unwrap();
-        let args = CString::new(command_info.args).unwrap();
-        let args_description =
-            CString::new(command_info.args_description).unwrap();
-        let completion = CString::new(command_info.completion).unwrap();
+        let name = LossyCString::new(command_info.name);
+        let description = LossyCString::new(command_info.description);
+        let args = LossyCString::new(command_info.args);
+        let args_description = LossyCString::new(command_info.args_description);
+        let completion = LossyCString::new(command_info.completion);
 
         let data = Box::new(CommandHookData {
             callback,

--- a/weechat-rs/src/infolist.rs
+++ b/weechat-rs/src/infolist.rs
@@ -2,13 +2,13 @@
 
 //! Weechat Infolist module.
 
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::os::raw::c_void;
 use std::ptr;
 
 use weechat_sys::{t_gui_buffer, t_infolist, t_weechat_plugin};
 
-use crate::{Buffer, Weechat};
+use crate::{Buffer, LossyCString, Weechat};
 
 /// Weechat Infolist type.
 pub struct Infolist {
@@ -36,8 +36,8 @@ impl Weechat {
         name: &str,
         arguments: &str,
     ) -> Option<Infolist> {
-        let name = CString::new(name).unwrap_or_default();
-        let arguments = CString::new(arguments).unwrap_or_default();
+        let name = LossyCString::new(name);
+        let arguments = LossyCString::new(arguments);
 
         let infolist_get = self.get().infolist_get.unwrap();
         let ptr = unsafe {
@@ -100,7 +100,7 @@ impl Infolist {
         let weechat = Weechat::from_ptr(self.weechat_ptr);
         let infolist_pointer = weechat.get().infolist_pointer.unwrap();
 
-        let name = CString::new(name).unwrap_or_default();
+        let name = LossyCString::new(name);
 
         unsafe { infolist_pointer(self.ptr, name.as_ptr()) }
     }
@@ -123,7 +123,7 @@ impl Infolist {
         let weechat = Weechat::from_ptr(self.weechat_ptr);
         let infolist_string = weechat.get().infolist_string.unwrap();
 
-        let name = CString::new(name).unwrap_or_default();
+        let name = LossyCString::new(name);
 
         unsafe {
             let ret = infolist_string(self.ptr, name.as_ptr());

--- a/weechat-rs/src/infolist.rs
+++ b/weechat-rs/src/infolist.rs
@@ -9,6 +9,7 @@ use std::ptr;
 use weechat_sys::{t_gui_buffer, t_infolist, t_weechat_plugin};
 
 use crate::{Buffer, LossyCString, Weechat};
+use std::borrow::Cow;
 
 /// Weechat Infolist type.
 pub struct Infolist {
@@ -83,7 +84,7 @@ impl Infolist {
     /// The types are: "i" (integer), "s" (string), "p" (pointer), "b" (buffer),
     /// "t" (time).
     /// Example: "i:my_integer,s:my_string"
-    pub fn fields(&self) -> Option<&str> {
+    pub fn fields(&self) -> Option<Cow<str>> {
         let weechat = Weechat::from_ptr(self.weechat_ptr);
         let infolist_fields = weechat.get().infolist_fields.unwrap();
         unsafe {
@@ -91,7 +92,7 @@ impl Infolist {
             if ret.is_null() {
                 None
             } else {
-                Some(CStr::from_ptr(ret).to_str().unwrap_or_default())
+                Some(CStr::from_ptr(ret).to_string_lossy())
             }
         }
     }
@@ -119,7 +120,7 @@ impl Infolist {
 
     /// Get the value of a string variable in the current infolist item.
     /// * `name` - The variable name of the infolist item.
-    pub fn get_string(&self, name: &str) -> Option<&str> {
+    pub fn get_string(&self, name: &str) -> Option<Cow<str>> {
         let weechat = Weechat::from_ptr(self.weechat_ptr);
         let infolist_string = weechat.get().infolist_string.unwrap();
 
@@ -130,7 +131,7 @@ impl Infolist {
             if ret.is_null() {
                 None
             } else {
-                Some(CStr::from_ptr(ret).to_str().unwrap_or_default())
+                Some(CStr::from_ptr(ret).to_string_lossy())
             }
         }
     }

--- a/weechat-rs/src/lib.rs
+++ b/weechat-rs/src/lib.rs
@@ -21,3 +21,16 @@ pub use config_options::{
 pub use hooks::{CommandDescription, CommandHook, FdHook, FdHookMode};
 
 pub use infolist::Infolist;
+use std::ffi::CString;
+
+pub(crate) struct LossyCString;
+
+impl LossyCString {
+    pub(crate) fn new<T: AsRef<str>>(t: T) -> CString {
+        match CString::new(t.as_ref()) {
+            Ok(cstr) => cstr,
+            Err(_) => CString::new(t.as_ref().replace('\0', ""))
+                .expect("string has no nulls"),
+        }
+    }
+}

--- a/weechat-rs/src/weechat.rs
+++ b/weechat-rs/src/weechat.rs
@@ -6,6 +6,7 @@ use weechat_sys::t_weechat_plugin;
 
 use crate::LossyCString;
 use libc::{c_char, c_int};
+use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::{ptr, vec};
 
@@ -110,20 +111,24 @@ impl Weechat {
 
     /// Return a string color code for display.
     /// * `color_name` - name the color
-    pub fn color(&self, color_name: &str) -> &str {
+    pub fn color(&self, color_name: &str) -> Cow<str> {
         let weechat_color = self.get().color.unwrap();
 
         let color_name = LossyCString::new(color_name);
         unsafe {
             let color = weechat_color(color_name.as_ptr());
-            CStr::from_ptr(color).to_str().unwrap_or_default()
+            CStr::from_ptr(color).to_string_lossy()
         }
     }
 
     /// Get some info from Weechat or a plugin.
     /// * `info_name` - name the info
     /// * `arguments` - arguments for the info
-    pub fn info_get(&self, info_name: &str, arguments: &str) -> Option<&str> {
+    pub fn info_get(
+        &self,
+        info_name: &str,
+        arguments: &str,
+    ) -> Option<Cow<str>> {
         let info_get = self.get().info_get.unwrap();
 
         let info_name = LossyCString::new(info_name);
@@ -135,7 +140,7 @@ impl Weechat {
             if info.is_null() {
                 None
             } else {
-                Some(CStr::from_ptr(info).to_str().unwrap_or_default())
+                Some(CStr::from_ptr(info).to_string_lossy())
             }
         }
     }

--- a/weechat-rs/src/weechat.rs
+++ b/weechat-rs/src/weechat.rs
@@ -4,6 +4,7 @@
 
 use weechat_sys::t_weechat_plugin;
 
+use crate::LossyCString;
 use libc::{c_char, c_int};
 use std::ffi::{CStr, CString};
 use std::{ptr, vec};
@@ -82,7 +83,7 @@ impl Weechat {
         let log_printf = self.get().log_printf.unwrap();
 
         let fmt = CString::new("%s").unwrap();
-        let msg = CString::new(msg).unwrap_or_default();
+        let msg = LossyCString::new(msg);
 
         unsafe {
             log_printf(fmt.as_ptr(), msg.as_ptr());
@@ -94,7 +95,7 @@ impl Weechat {
         let printf_date_tags = self.get().printf_date_tags.unwrap();
 
         let fmt = CString::new("%s").unwrap();
-        let msg = CString::new(msg).unwrap();
+        let msg = LossyCString::new(msg);
 
         unsafe {
             printf_date_tags(
@@ -112,7 +113,7 @@ impl Weechat {
     pub fn color(&self, color_name: &str) -> &str {
         let weechat_color = self.get().color.unwrap();
 
-        let color_name = CString::new(color_name).unwrap_or_default();
+        let color_name = LossyCString::new(color_name);
         unsafe {
             let color = weechat_color(color_name.as_ptr());
             CStr::from_ptr(color).to_str().unwrap_or_default()
@@ -125,8 +126,8 @@ impl Weechat {
     pub fn info_get(&self, info_name: &str, arguments: &str) -> Option<&str> {
         let info_get = self.get().info_get.unwrap();
 
-        let info_name = CString::new(info_name).unwrap_or_default();
-        let arguments = CString::new(arguments).unwrap_or_default();
+        let info_name = LossyCString::new(info_name);
+        let arguments = LossyCString::new(arguments);
 
         unsafe {
             let info =


### PR DESCRIPTION
Make all string -> CString and CStr -> str conversions lossy, so that null bytes and invalid utf-8 are stripped.

Closes #4