### PR TITLE
Hook and callback additions

### DIFF
--- a/weechat-rs/src/bar.rs
+++ b/weechat-rs/src/bar.rs
@@ -22,6 +22,10 @@ pub struct BarItem {
 
 impl Drop for BarItem {
     fn drop(&mut self) {
+        // don't unhook the "partial" objects passed to callbacks
+        if self._data.is_none() {
+            return;
+        }
         let weechat = Weechat::from_ptr(self.weechat_ptr);
         let bar_item_remove = weechat.get().bar_item_remove.unwrap();
         unsafe { bar_item_remove(self.ptr) };

--- a/weechat-rs/src/bar.rs
+++ b/weechat-rs/src/bar.rs
@@ -12,13 +12,14 @@ struct BarItemCbData {
     weechat_ptr: *mut t_weechat_plugin,
 }
 
+/// A handle to a bar item.
 pub struct BarItem {
     ptr: *mut t_gui_bar_item,
     _data: Option<Box<BarItemCbData>>,
 }
 
 impl Weechat {
-    // TODO: Provide window object
+    // TODO: Provide window object, the callback should accept a Window object wrapping a t_gui_window
     pub fn new_bar_item(
         &self,
         name: &str,

--- a/weechat-rs/src/bar.rs
+++ b/weechat-rs/src/bar.rs
@@ -1,0 +1,85 @@
+use core::ptr;
+use libc::c_char;
+use std::os::raw::c_void;
+use weechat_sys::{
+    t_gui_bar_item, t_gui_buffer, t_gui_window, t_hashtable, t_weechat_plugin,
+};
+
+use crate::{Buffer, LossyCString, Weechat};
+
+struct BarItemCbData {
+    callback: fn(item: &BarItem, buffer: &Buffer) -> String,
+    weechat_ptr: *mut t_weechat_plugin,
+}
+
+pub struct BarItem {
+    ptr: *mut t_gui_bar_item,
+    _data: Option<Box<BarItemCbData>>,
+}
+
+impl Weechat {
+    // TODO: Provide window object
+    pub fn new_bar_item(
+        &self,
+        name: &str,
+        callback: fn(item: &BarItem, buffer: &Buffer) -> String,
+    ) -> BarItem {
+        unsafe extern "C" fn c_item_cb(
+            pointer: *const c_void,
+            _data: *mut c_void,
+            bar_item: *mut t_gui_bar_item,
+            _window: *mut t_gui_window,
+            buffer: *mut t_gui_buffer,
+            _extra_info: *mut t_hashtable,
+        ) -> *mut c_char {
+            let data: &mut BarItemCbData =
+                { &mut *(pointer as *mut BarItemCbData) };
+            let callback = data.callback;
+            let buffer = Buffer::from_ptr(data.weechat_ptr, buffer);
+
+            let item = BarItem {
+                ptr: bar_item,
+                _data: None,
+            };
+
+            // weechat wants malloc'ed string
+            libc::strdup(LossyCString::new(callback(&item, &buffer)).as_ptr())
+        }
+
+        let data = Box::new(BarItemCbData {
+            callback,
+            weechat_ptr: self.ptr,
+        });
+
+        let data_ref = Box::leak(data);
+        let bar_item_new = self.get().bar_item_new.unwrap();
+
+        let bar_item_name = LossyCString::new(name);
+
+        let hook_ptr = unsafe {
+            bar_item_new(
+                self.ptr,
+                bar_item_name.as_ptr(),
+                Some(c_item_cb),
+                data_ref as *const _ as *const c_void,
+                ptr::null_mut(),
+            )
+        };
+
+        let hook_data = unsafe { Box::from_raw(data_ref) };
+
+        BarItem {
+            ptr: hook_ptr,
+            _data: Some(hook_data),
+        }
+    }
+
+    /// Triggers a bar update to update by calling its callback
+    pub fn update_bar_item(&self, name: &str) {
+        let bar_item_update = self.get().bar_item_update.unwrap();
+
+        let name = LossyCString::new(name);
+
+        unsafe { bar_item_update(name.as_ptr()) }
+    }
+}

--- a/weechat-rs/src/bar.rs
+++ b/weechat-rs/src/bar.rs
@@ -12,10 +12,20 @@ struct BarItemCbData {
     weechat_ptr: *mut t_weechat_plugin,
 }
 
-/// A handle to a bar item.
+/// A handle to a bar item. The bar item is automatically removed when the object is
+/// dropped.
 pub struct BarItem {
     ptr: *mut t_gui_bar_item,
+    weechat_ptr: *mut t_weechat_plugin,
     _data: Option<Box<BarItemCbData>>,
+}
+
+impl Drop for BarItem {
+    fn drop(&mut self) {
+        let weechat = Weechat::from_ptr(self.weechat_ptr);
+        let bar_item_remove = weechat.get().bar_item_remove.unwrap();
+        unsafe { bar_item_remove(self.ptr) };
+    }
 }
 
 impl Weechat {
@@ -40,6 +50,7 @@ impl Weechat {
 
             let item = BarItem {
                 ptr: bar_item,
+                weechat_ptr: data.weechat_ptr,
                 _data: None,
             };
 
@@ -71,6 +82,7 @@ impl Weechat {
 
         BarItem {
             ptr: hook_ptr,
+            weechat_ptr: self.ptr,
             _data: Some(hook_data),
         }
     }

--- a/weechat-rs/src/completion.rs
+++ b/weechat-rs/src/completion.rs
@@ -1,0 +1,157 @@
+use libc::{c_char, c_int};
+use std::ffi::{CStr, CString};
+use std::os::raw::c_void;
+use std::ptr;
+
+use weechat_sys::{t_gui_buffer, t_gui_completion, t_weechat_plugin};
+
+use crate::hooks::Hook;
+use crate::{Buffer, LossyCString, ReturnCode, Weechat};
+
+pub struct Completion {
+    weechat_ptr: *mut t_weechat_plugin,
+    ptr: *mut t_gui_completion,
+}
+
+#[derive(Clone, Copy)]
+pub enum CompletionInsertionMethod {
+    Sorted,
+    Beginning,
+    End,
+}
+
+impl CompletionInsertionMethod {
+    pub(crate) fn value(&self) -> &str {
+        match self {
+            CompletionInsertionMethod::Sorted => "sort",
+            CompletionInsertionMethod::Beginning => "beginning",
+            CompletionInsertionMethod::End => "end",
+        }
+    }
+}
+
+impl Completion {
+    pub(crate) fn from_raw(
+        weechat: *mut t_weechat_plugin,
+        completion: *mut t_gui_completion,
+    ) -> Completion {
+        Completion {
+            weechat_ptr: weechat,
+            ptr: completion,
+        }
+    }
+
+    pub fn add(&self, word: &str) {
+        self.add_with_options(word, false, CompletionInsertionMethod::Sorted)
+    }
+
+    pub fn add_with_options(
+        &self,
+        word: &str,
+        nick: bool,
+        method: CompletionInsertionMethod,
+    ) {
+        let weechat = Weechat::from_ptr(self.weechat_ptr);
+
+        let hook_completion_list_add =
+            weechat.get().hook_completion_list_add.unwrap();
+
+        let word = LossyCString::new(word);
+        let method = CString::new(method.value()).unwrap();
+
+        unsafe {
+            hook_completion_list_add(
+                self.ptr,
+                word.as_ptr(),
+                nick as i32,
+                method.as_ptr(),
+            );
+        }
+    }
+}
+
+pub struct CompletionHook<T> {
+    _hook: Hook,
+    _hook_data: Box<CompletionHookData<T>>,
+}
+
+struct CompletionHookData<T> {
+    callback: fn(&T, Buffer, &str, Completion) -> ReturnCode,
+    callback_data: T,
+    weechat_ptr: *mut t_weechat_plugin,
+}
+
+impl Weechat {
+    pub fn hook_completion<T>(
+        &self,
+        completion_item: &str,
+        description: &str,
+        callback: fn(
+            data: &T,
+            buffer: Buffer,
+            item: &str,
+            completion: Completion,
+        ) -> ReturnCode,
+        callback_data: Option<T>,
+    ) -> CompletionHook<T>
+    where
+        T: Default,
+    {
+        unsafe extern "C" fn c_hook_cb<T>(
+            pointer: *const c_void,
+            _data: *mut c_void,
+            completion_item: *const c_char,
+            buffer: *mut t_gui_buffer,
+            completion: *mut t_gui_completion,
+        ) -> c_int {
+            let hook_data: &mut CompletionHookData<T> =
+                { &mut *(pointer as *mut CompletionHookData<T>) };
+            let callback = hook_data.callback;
+            let callback_data = &hook_data.callback_data;
+            let buffer = Buffer::from_ptr(hook_data.weechat_ptr, buffer);
+
+            let completion_item =
+                CStr::from_ptr(completion_item).to_str().unwrap_or_default();
+
+            callback(
+                callback_data,
+                buffer,
+                completion_item,
+                Completion::from_raw(hook_data.weechat_ptr, completion),
+            ) as i32
+        }
+
+        let data = Box::new(CompletionHookData {
+            callback,
+            callback_data: callback_data.unwrap_or_default(),
+            weechat_ptr: self.ptr,
+        });
+
+        let data_ref = Box::leak(data);
+        let hook_completion = self.get().hook_completion.unwrap();
+
+        let completion_item = LossyCString::new(completion_item);
+        let description = LossyCString::new(description);
+
+        let hook_ptr = unsafe {
+            hook_completion(
+                self.ptr,
+                completion_item.as_ptr(),
+                description.as_ptr(),
+                Some(c_hook_cb::<T>),
+                data_ref as *const _ as *const c_void,
+                ptr::null_mut(),
+            )
+        };
+        let hook_data = unsafe { Box::from_raw(data_ref) };
+        let hook = Hook {
+            ptr: hook_ptr,
+            weechat_ptr: self.ptr,
+        };
+
+        CompletionHook::<T> {
+            _hook: hook,
+            _hook_data: hook_data,
+        }
+    }
+}

--- a/weechat-rs/src/hooks.rs
+++ b/weechat-rs/src/hooks.rs
@@ -6,13 +6,15 @@
 //! This module contains hook creation methods for the `Weechat` object.
 
 use libc::{c_char, c_int};
+use std::borrow::Cow;
+use std::ffi::CStr;
 use std::os::raw::c_void;
 use std::os::unix::io::AsRawFd;
 use std::ptr;
 
 use weechat_sys::{t_gui_buffer, t_hook, t_weechat_plugin, WEECHAT_RC_OK};
 
-use crate::{ArgsWeechat, Buffer, LossyCString, Weechat};
+use crate::{ArgsWeechat, Buffer, LossyCString, ReturnCode, Weechat};
 
 /// Weechat Hook type. The hook is unhooked automatically when the object is
 /// dropped.
@@ -21,11 +23,25 @@ pub(crate) struct Hook {
     pub(crate) weechat_ptr: *mut t_weechat_plugin,
 }
 
+impl Drop for Hook {
+    fn drop(&mut self) {
+        let weechat = Weechat::from_ptr(self.weechat_ptr);
+        let unhook = weechat.get().unhook.unwrap();
+        unsafe { unhook(self.ptr) };
+    }
+}
+
 /// Hook for a weechat command, the command is removed when the object is
 /// dropped.
 pub struct CommandHook<T> {
     _hook: Hook,
     _hook_data: Box<CommandHookData<T>>,
+}
+
+struct CommandHookData<T> {
+    callback: fn(&T, Buffer, ArgsWeechat),
+    callback_data: T,
+    weechat_ptr: *mut t_weechat_plugin,
 }
 
 /// Setting for the FdHook.
@@ -36,24 +52,6 @@ pub enum FdHookMode {
     Write,
     /// Catch read and write events.
     ReadWrite,
-}
-
-/// Hook for a file descriptor, the hook is removed when the object is dropped.
-pub struct FdHook<T, F> {
-    _hook: Hook,
-    _hook_data: Box<FdHookData<T, F>>,
-}
-
-struct FdHookData<T, F> {
-    callback: fn(&T, fd_object: &mut F),
-    callback_data: T,
-    fd_object: F,
-}
-
-struct CommandHookData<T> {
-    callback: fn(&T, Buffer, ArgsWeechat),
-    callback_data: T,
-    weechat_ptr: *mut t_weechat_plugin,
 }
 
 impl FdHookMode {
@@ -73,12 +71,87 @@ impl FdHookMode {
     }
 }
 
-impl Drop for Hook {
-    fn drop(&mut self) {
-        let weechat = Weechat::from_ptr(self.weechat_ptr);
-        let unhook = weechat.get().unhook.unwrap();
-        unsafe { unhook(self.ptr) };
+/// Hook for a file descriptor, the hook is removed when the object is dropped.
+pub struct FdHook<T, F> {
+    _hook: Hook,
+    _hook_data: Box<FdHookData<T, F>>,
+}
+
+struct FdHookData<T, F> {
+    callback: fn(&T, fd_object: &mut F),
+    callback_data: T,
+    fd_object: F,
+}
+
+pub struct CommandRunHook<T> {
+    _hook: Hook,
+    _hook_data: Box<CommandRunHookData<T>>,
+}
+
+struct CommandRunHookData<T> {
+    callback: fn(&T, Buffer, Cow<str>) -> ReturnCode,
+    callback_data: T,
+    weechat_ptr: *mut t_weechat_plugin,
+}
+
+pub struct SignalHook<T> {
+    _hook: Hook,
+    _hook_data: Box<SignalHookData<T>>,
+}
+
+struct SignalHookData<T> {
+    callback: fn(&T, &Weechat, SignalHookValue) -> ReturnCode,
+    callback_data: T,
+    weechat_ptr: *mut t_weechat_plugin,
+}
+
+/// The type of data returned by a signal
+#[derive(Debug)]
+pub enum SignalHookValue {
+    /// String data returned by a signal
+    String(String),
+    /// An Integer returned by a signal
+    Integer(i32),
+    /// A Pointer returned by a signal
+    Pointer(*mut c_void),
+}
+
+impl SignalHookValue {
+    pub(crate) fn from_raw_with_type(
+        data_type: &str,
+        data: *mut c_void,
+    ) -> Option<SignalHookValue> {
+        match data_type {
+            "string" => unsafe {
+                Some(SignalHookValue::String(
+                    CStr::from_ptr(data as *const c_char)
+                        .to_string_lossy()
+                        .into_owned(),
+                ))
+            },
+            "integer" => {
+                let data = data as *const c_int;
+                if data.is_null() {
+                    None
+                } else {
+                    unsafe { Some(SignalHookValue::Integer(*(data))) }
+                }
+            }
+            "pointer" => Some(SignalHookValue::Pointer(data)),
+            _ => None,
+        }
     }
+}
+
+pub struct TimerHook<T> {
+    _hook: Hook,
+    _hook_data: Box<TimerHookData<T>>,
+}
+
+struct TimerHookData<T> {
+    callback: fn(&T, &Weechat, i32),
+    callback_data: T,
+    weechat_ptr: *mut t_weechat_plugin,
 }
 
 #[derive(Default)]
@@ -240,6 +313,198 @@ impl Weechat {
         };
 
         FdHook::<T, F> {
+            _hook: hook,
+            _hook_data: hook_data,
+        }
+    }
+
+    pub fn hook_timer<T>(
+        &self,
+        interval: i64,
+        align_second: i32,
+        max_calls: i32,
+        callback: fn(data: &T, weechat: &Weechat, remaining: i32),
+        callback_data: Option<T>,
+    ) -> TimerHook<T>
+    where
+        T: Default,
+    {
+        unsafe extern "C" fn c_hook_cb<T>(
+            pointer: *const c_void,
+            _data: *mut c_void,
+            remaining: i32,
+        ) -> c_int {
+            let hook_data: &mut TimerHookData<T> =
+                { &mut *(pointer as *mut TimerHookData<T>) };
+            let callback = &hook_data.callback;
+            let callback_data = &hook_data.callback_data;
+
+            callback(
+                callback_data,
+                &Weechat::from_ptr(hook_data.weechat_ptr),
+                remaining,
+            );
+
+            WEECHAT_RC_OK
+        }
+
+        let data = Box::new(TimerHookData::<T> {
+            callback,
+            callback_data: callback_data.unwrap_or_default(),
+            weechat_ptr: self.ptr,
+        });
+
+        let data_ref = Box::leak(data);
+        let hook_timer = self.get().hook_timer.unwrap();
+
+        let hook_ptr = unsafe {
+            hook_timer(
+                self.ptr,
+                interval,
+                align_second,
+                max_calls,
+                Some(c_hook_cb::<T>),
+                data_ref as *const _ as *const c_void,
+                ptr::null_mut(),
+            )
+        };
+        let hook_data = unsafe { Box::from_raw(data_ref) };
+        let hook = Hook {
+            ptr: hook_ptr,
+            weechat_ptr: self.ptr,
+        };
+
+        TimerHook {
+            _hook: hook,
+            _hook_data: hook_data,
+        }
+    }
+
+    pub fn hook_command_run<T>(
+        &self,
+        command: &str,
+        callback: fn(data: &T, buffer: Buffer, command: Cow<str>) -> ReturnCode,
+        callback_data: Option<T>,
+    ) -> CommandRunHook<T>
+    where
+        T: Default,
+    {
+        unsafe extern "C" fn c_hook_cb<T>(
+            pointer: *const c_void,
+            _data: *mut c_void,
+            buffer: *mut t_gui_buffer,
+            command: *const std::os::raw::c_char,
+        ) -> c_int {
+            let hook_data: &mut CommandRunHookData<T> =
+                { &mut *(pointer as *mut CommandRunHookData<T>) };
+            let callback = hook_data.callback;
+            let callback_data = &hook_data.callback_data;
+
+            let buffer = Buffer::from_ptr(hook_data.weechat_ptr, buffer);
+            let command = CStr::from_ptr(command).to_string_lossy();
+
+            callback(callback_data, buffer, command) as isize as i32
+        }
+
+        let data = Box::new(CommandRunHookData {
+            callback,
+            callback_data: callback_data.unwrap_or_default(),
+            weechat_ptr: self.ptr,
+        });
+
+        let data_ref = Box::leak(data);
+        let hook_timer = self.get().hook_command_run.unwrap();
+
+        let command = LossyCString::new(command);
+
+        let hook_ptr = unsafe {
+            hook_timer(
+                self.ptr,
+                command.as_ptr(),
+                Some(c_hook_cb::<T>),
+                data_ref as *const _ as *const c_void,
+                ptr::null_mut(),
+            )
+        };
+        let hook_data = unsafe { Box::from_raw(data_ref) };
+        let hook = Hook {
+            ptr: hook_ptr,
+            weechat_ptr: self.ptr,
+        };
+
+        CommandRunHook::<T> {
+            _hook: hook,
+            _hook_data: hook_data,
+        }
+    }
+
+    pub fn hook_signal<T>(
+        &self,
+        signal: &str,
+        callback: fn(
+            data: &T,
+            weechat: &Weechat,
+            signal_value: SignalHookValue,
+        ) -> ReturnCode,
+        callback_data: Option<T>,
+    ) -> SignalHook<T>
+    where
+        T: Default,
+    {
+        unsafe extern "C" fn c_hook_cb<T>(
+            pointer: *const c_void,
+            _data: *mut c_void,
+            _signal: *const c_char,
+            data_type: *const c_char,
+            signal_data: *mut c_void,
+        ) -> c_int {
+            let hook_data: &mut SignalHookData<T> =
+                { &mut *(pointer as *mut SignalHookData<T>) };
+            let callback = hook_data.callback;
+            let callback_data = &hook_data.callback_data;
+
+            let data_type =
+                CStr::from_ptr(data_type).to_str().unwrap_or_default();
+            if let Some(value) =
+                SignalHookValue::from_raw_with_type(data_type, signal_data)
+            {
+                callback(
+                    callback_data,
+                    &Weechat::from_ptr(hook_data.weechat_ptr),
+                    value,
+                ) as i32
+            } else {
+                WEECHAT_RC_OK
+            }
+        }
+
+        let data = Box::new(SignalHookData {
+            callback,
+            callback_data: callback_data.unwrap_or_default(),
+            weechat_ptr: self.ptr,
+        });
+
+        let data_ref = Box::leak(data);
+        let hook_signal = self.get().hook_signal.unwrap();
+
+        let signal = LossyCString::new(signal);
+
+        let hook_ptr = unsafe {
+            hook_signal(
+                self.ptr,
+                signal.as_ptr(),
+                Some(c_hook_cb::<T>),
+                data_ref as *const _ as *const c_void,
+                ptr::null_mut(),
+            )
+        };
+        let hook_data = unsafe { Box::from_raw(data_ref) };
+        let hook = Hook {
+            ptr: hook_ptr,
+            weechat_ptr: self.ptr,
+        };
+
+        SignalHook::<T> {
             _hook: hook,
             _hook_data: hook_data,
         }

--- a/weechat-rs/src/hooks.rs
+++ b/weechat-rs/src/hooks.rs
@@ -463,6 +463,7 @@ impl Weechat {
             let callback = hook_data.callback;
             let callback_data = &hook_data.callback_data;
 
+            // this cannot contain invalid utf
             let data_type =
                 CStr::from_ptr(data_type).to_str().unwrap_or_default();
             if let Some(value) =

--- a/weechat-rs/src/lib.rs
+++ b/weechat-rs/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod buffer;
+pub mod completion;
 pub mod config;
 pub mod config_options;
 pub mod hooks;

--- a/weechat-rs/src/lib.rs
+++ b/weechat-rs/src/lib.rs
@@ -11,7 +11,7 @@ pub mod weechat;
 pub use weechat_macro::weechat_plugin;
 
 pub use plugin::{WeechatPlugin, WeechatResult};
-pub use weechat::{ArgsWeechat, Weechat};
+pub use weechat::{ArgsWeechat, OptionChanged, Weechat};
 
 pub use buffer::{Buffer, Nick, NickArgs};
 
@@ -20,7 +20,12 @@ pub use config_options::{
     BooleanOption, ColorOption, ConfigOption, IntegerOption, StringOption,
 };
 
-pub use hooks::{CommandDescription, CommandHook, FdHook, FdHookMode};
+pub use hooks::{
+    CommandDescription, CommandHook, CommandRunHook, FdHook, FdHookMode,
+    SignalHook, SignalHookValue, TimerHook,
+};
+
+pub use completion::{Completion, CompletionHook, CompletionInsertionMethod};
 
 pub use infolist::Infolist;
 

--- a/weechat-rs/src/lib.rs
+++ b/weechat-rs/src/lib.rs
@@ -25,7 +25,7 @@ pub use hooks::{
     SignalHook, SignalHookValue, TimerHook,
 };
 
-pub use completion::{Completion, CompletionHook, CompletionInsertionMethod};
+pub use completion::{Completion, CompletionHook, CompletionPosition};
 
 pub use infolist::Infolist;
 

--- a/weechat-rs/src/lib.rs
+++ b/weechat-rs/src/lib.rs
@@ -21,7 +21,15 @@ pub use config_options::{
 pub use hooks::{CommandDescription, CommandHook, FdHook, FdHookMode};
 
 pub use infolist::Infolist;
+
 use std::ffi::CString;
+
+/// Status values for weechat callbacks
+pub enum ReturnCode {
+    Ok = weechat_sys::WEECHAT_RC_OK as isize,
+    OkEat = weechat_sys::WEECHAT_RC_OK_EAT as isize,
+    Error = weechat_sys::WEECHAT_RC_ERROR as isize,
+}
 
 pub(crate) struct LossyCString;
 

--- a/weechat-rs/src/lib.rs
+++ b/weechat-rs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bar;
 pub mod buffer;
 pub mod completion;
 pub mod config;


### PR DESCRIPTION
This adds timer, signal, and command_run hooks as well as basic support for bar items and completion.

I decided to leave the function pointers because using `Fn` traits was leaking into the api badly and I didn't see much point switching everything to boxes.