### PR TITLE
relax plugin macro's requirements on field values

### DIFF
--- a/weechat-macro/Cargo.toml
+++ b/weechat-macro/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 libc = "0.2.80"
-syn = "1.0.48"
+syn = { version = "1.0.48", features = ["full"] }
 proc-macro2 = "1.0.24"
 quote = "1.0.7"
 

--- a/weechat/examples/go/rust-toolchain
+++ b/weechat/examples/go/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/weechat/examples/go/src/lib.rs
+++ b/weechat/examples/go/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(const_raw_ptr_deref)]
+
 // Copyright (C) 2010 m4v <lambdae2@gmail.com>
 // Copyright (C) 2011 stfn <stfnmd@googlemail.com>
 // Copyright (C) 2009-2014 Sébastien Helleu <flashcode@flashtux.org>

--- a/weechat/examples/grep/rust-toolchain
+++ b/weechat/examples/grep/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/weechat/examples/grep/src/lib.rs
+++ b/weechat/examples/grep/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(const_raw_ptr_deref)]
+
 mod buffer;
 
 use clap::{App, Arg};

--- a/weechat/examples/infolist/rust-toolchain
+++ b/weechat/examples/infolist/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/weechat/examples/infolist/src/lib.rs
+++ b/weechat/examples/infolist/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(const_raw_ptr_deref)]
+
 // Copyright (C) 2008-2018 Sébastien Helleu <flashcode@flashtux.org>
 // Copyright (C) 2020 Damir Jelić <poljar@termina.org.uk>
 //

--- a/weechat/examples/sample/rust-toolchain
+++ b/weechat/examples/sample/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/weechat/examples/sample/src/lib.rs
+++ b/weechat/examples/sample/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(const_raw_ptr_deref)]
+
 use std::{borrow::Cow, time::Instant};
 use weechat::{
     buffer::{Buffer, BufferBuilder, NickSettings},
@@ -154,9 +156,9 @@ impl Drop for SamplePlugin {
 
 plugin!(
     SamplePlugin,
-    name: "rust_sample",
-    author: "Damir Jelić <poljar@termina.org.uk>",
+    name: env!("CARGO_PKG_NAME"),
+    author: env!("CARGO_PKG_AUTHORS"),
     description: "",
-    version: "0.1.0",
+    version: env!("CARGO_PKG_VERSION"),
     license: "MIT"
 );


### PR DESCRIPTION
From "string literal" to basically still "string literal", but now you can use macros to generate the string literal. Did I mention string literals? Anyway, this is particularly useful in combination with the `env!()` macro and the environment variables `cargo` sets at build time.

See #28 for initial discussion. Also, I've done a force-push to add a few comments since then. And just to make things easier to follow/reference, I'll restate here that these changes currently require downstream crates to use a nightly toolchain due to https://github.com/rust-lang/rust/issues/51911.