### PR TITLE
buffer: Implement hide and unhide

### DIFF
--- a/weechat/src/buffer/mod.rs
+++ b/weechat/src/buffer/mod.rs
@@ -1425,4 +1425,14 @@ impl Buffer<'_> {
             })
         }
     }
+
+    /// Hide the buffer from the buflist.
+    pub fn hide(&self) {
+        self.set("hidden", "1");
+    }
+
+    /// Unhide the buffer from the buflist.
+    pub fn unhide(&self) {
+        self.set("hidden", "0");
+    }
 }


### PR DESCRIPTION
This PR introduces two setter functions `hide()` and
`unhide()` in the `Buffer` module to hide or unhide a buffer from the
buflist.