### PR TITLE
patch to build on aarch64

### DIFF
--- a/weechat/src/config/config.rs
+++ b/weechat/src/config/config.rs
@@ -1,4 +1,3 @@
-use libc::{c_char, c_int};
 use std::{
     borrow::Cow,
     cell::RefCell,
@@ -6,7 +5,7 @@ use std::{
     ffi::CStr,
     io::{Error as IoError, ErrorKind},
     marker::PhantomData,
-    os::raw::c_void,
+    os::raw::{c_char, c_int, c_void},
     ptr,
     rc::Rc,
 };

--- a/weechat/src/config/section.rs
+++ b/weechat/src/config/section.rs
@@ -1,10 +1,9 @@
-use libc::{c_char, c_int};
 use std::{
     cell::{Ref, RefCell, RefMut},
     collections::HashMap,
     ffi::CStr,
     ops::{Deref, DerefMut},
-    os::raw::c_void,
+    os::raw::{c_char, c_int, c_void},
     ptr,
     rc::Weak,
 };
@@ -395,8 +394,8 @@ pub(crate) type SectionReadCbT = unsafe extern "C" fn(
     _data: *mut c_void,
     _config: *mut t_config_file,
     _section: *mut t_config_section,
-    option_name: *const i8,
-    value: *const i8,
+    option_name: *const c_char,
+    value: *const c_char,
 ) -> c_int;
 
 pub(crate) type SectionWriteCbT = unsafe extern "C" fn(

--- a/weechat/src/hashtable.rs
+++ b/weechat/src/hashtable.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ffi::c_void};
+use std::{collections::HashMap, ffi::c_void, os::raw::c_char};
 
 use weechat_sys::{t_hashtable, WEECHAT_HASHTABLE_STRING};
 
@@ -8,7 +8,7 @@ impl Weechat {
     pub(crate) fn hashmap_to_weechat(&self, hashmap: HashMap<&str, &str>) -> *mut t_hashtable {
         let hashtable_new = self.get().hashtable_new.unwrap();
 
-        let table_type: *const i8 = WEECHAT_HASHTABLE_STRING as *const _ as *const i8;
+        let table_type: *const c_char = WEECHAT_HASHTABLE_STRING as *const _ as *const c_char;
 
         let hashtable = unsafe { hashtable_new(8, table_type, table_type, None, None) };
 

--- a/weechat/src/hdata.rs
+++ b/weechat/src/hdata.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     ffi::{c_void, CStr},
+    os::raw::c_char,
 };
 use weechat_sys::t_hdata;
 
@@ -57,7 +58,7 @@ impl Weechat {
         hdata: *mut t_hdata,
         pointer: *mut c_void,
         name: &str,
-    ) -> i8 {
+    ) -> c_char {
         let hdata_char = self.get().hdata_char.unwrap();
         let name = LossyCString::new(name);
 

--- a/weechat/src/hooks/signal.rs
+++ b/weechat/src/hooks/signal.rs
@@ -1,5 +1,11 @@
-use libc::{c_char, c_int};
-use std::{borrow::Cow, cell::Cell, ffi::CStr, os::raw::c_void, ptr, rc::Rc};
+use std::{
+    borrow::Cow,
+    cell::Cell,
+    ffi::CStr,
+    os::raw::{c_char, c_int, c_void},
+    ptr,
+    rc::Rc,
+};
 
 use weechat_sys::{t_gui_buffer, t_weechat_plugin};
 
@@ -327,7 +333,7 @@ impl Weechat {
             unsafe {
                 signal_send(
                     signal_name.as_ptr(),
-                    weechat_sys::WEECHAT_HOOK_SIGNAL_STRING as *const _ as *const i8,
+                    weechat_sys::WEECHAT_HOOK_SIGNAL_STRING as *const _ as *const c_char,
                     string.as_ptr() as *mut _,
                 )
             }
@@ -343,7 +349,7 @@ impl Weechat {
                 ),
                 SignalData::String(_) => unreachable!(),
             };
-            unsafe { signal_send(signal_name.as_ptr(), data_type as *const i8, ptr) }
+            unsafe { signal_send(signal_name.as_ptr(), data_type as *const c_char, ptr) }
         };
 
         match ret {


### PR DESCRIPTION
pointers have different types on different architectures. on aarch64 this means that rust-weechat fails to build. os::raw provides the suitable types to address this.