### PR TITLE
examples/go: Fix wrong config description

### DIFF
--- a/weechat/examples/go/src/lib.rs
+++ b/weechat/examples/go/src/lib.rs
@@ -132,7 +132,7 @@ config!(
         },
 
         buffer_numbers: bool {
-            "Automatically jump to a buffer when it is uniquely selected.",
+            "Display buffer numbers.",
             false,
         },
     }


### PR DESCRIPTION
Seems to have been copied from the previous entry