### PR TITLE
Fix bitness issues

### DIFF
--- a/crates/weechat-sys/src/weechat-plugin.h
+++ b/crates/weechat-sys/src/weechat-plugin.h
@@ -430,7 +430,7 @@ struct t_weechat_plugin
     /* crypto */
     int (*crypto_hash) (const void *data, int data_size,
                         const char *hash_algo, void *hash, int *hash_size);
-    int (*crypto_hash_file) (const char *fliename,
+    int (*crypto_hash_file) (const char *filename,
                              const char *hash_algo, void *hash, int *hash_size);
     int (*crypto_hash_pbkdf2) (const void *data, int data_size,
                                const char *hash_algo,

--- a/crates/weechat/src/buffer/lines.rs
+++ b/crates/weechat/src/buffer/lines.rs
@@ -134,7 +134,7 @@ impl<'a> BufferLine<'a> {
     }
 
     /// Get the date of the line.
-    pub fn date(&self) -> i64 {
+    pub fn date(&self) -> isize {
         unsafe { self.weechat.hdata_time(self.hdata(), self.line_data_pointer, "date") }
     }
 
@@ -151,7 +151,7 @@ impl<'a> BufferLine<'a> {
     }
 
     /// Get the date the line was printed.
-    pub fn date_printed(&self) -> i64 {
+    pub fn date_printed(&self) -> isize {
         unsafe { self.weechat.hdata_time(self.hdata(), self.line_data_pointer, "date_printed") }
     }
 

--- a/crates/weechat/src/buffer/mod.rs
+++ b/crates/weechat/src/buffer/mod.rs
@@ -776,7 +776,7 @@ impl Buffer<'_> {
     /// * `tags` - A list of tags that will be applied to the printed line.
     ///
     /// * `message` - The message that will be displayed.
-    pub fn print_date_tags(&self, date: i64, tags: &[&str], message: &str) {
+    pub fn print_date_tags(&self, date: isize, tags: &[&str], message: &str) {
         let weechat = self.weechat();
         let printf_date_tags = weechat.get().printf_datetime_tags.unwrap();
 
@@ -786,7 +786,14 @@ impl Buffer<'_> {
         let message = LossyCString::new(message);
 
         unsafe {
-            printf_date_tags(self.ptr(), date, 0, tags.as_ptr(), fmt_str.as_ptr(), message.as_ptr())
+            printf_date_tags(
+                self.ptr(),
+                date as _,
+                0,
+                tags.as_ptr(),
+                fmt_str.as_ptr(),
+                message.as_ptr(),
+            )
         }
     }
 

--- a/crates/weechat/src/config/config.rs
+++ b/crates/weechat/src/config/config.rs
@@ -605,10 +605,7 @@ impl Conf {
 
         let option_name = LossyCString::new(key);
 
-        let c_value = match value {
-            Some(v) => LossyCString::new(v).as_ptr(),
-            None => ptr::null(),
-        };
+        let c_value = value.map(LossyCString::new).map(|v| v.as_ptr()).unwrap_or(ptr::null());
 
         unsafe {
             write_line(self.ptr, option_name.as_ptr(), c_value);

--- a/crates/weechat/src/hdata.rs
+++ b/crates/weechat/src/hdata.rs
@@ -47,11 +47,11 @@ impl Weechat {
         hdata: *mut t_hdata,
         pointer: *mut c_void,
         name: &str,
-    ) -> i64 {
+    ) -> isize {
         let hdata_time = self.get().hdata_time.unwrap();
         let name = LossyCString::new(name);
 
-        hdata_time(hdata, pointer, name.as_ptr())
+        hdata_time(hdata, pointer, name.as_ptr()) as _
     }
 
     pub(crate) unsafe fn hdata_char(


### PR DESCRIPTION
Replaces `i64` with `isize` for ffi functions that operate on `time_t` which is `c_long` that is either `i32` or `i64` based on the platform, this way it can cleanly cast between types

Example signature (copied from generated bindings):

```rust
pub type __time_t = ::std::os::raw::c_long;
pub type __suseconds_t = ::std::os::raw::c_long;
pub type __socklen_t = ::std::os::raw::c_uint;
pub type time_t = __time_t;
[...]
pub printf_datetime_tags: ::std::option::Option<
        unsafe extern "C" fn(
            buffer: *mut t_gui_buffer,
            date: time_t,
            date_usec: ::std::os::raw::c_int,
            tags: *const ::std::os::raw::c_char,
            message: *const ::std::os::raw::c_char,
            ...
        ),
    >,
```

Fixes https://github.com/poljar/weechat-matrix-rs/issues/84
Fixes https://github.com/poljar/rust-weechat/issues/34