### PR TITLE
weechat: align date to weechat api type

### DIFF
--- a/crates/weechat/src/buffer/lines.rs
+++ b/crates/weechat/src/buffer/lines.rs
@@ -75,8 +75,8 @@ impl DoubleEndedIterator for BufferLines<'_> {
 pub struct LineData<'a> {
     pub prefix: Option<&'a str>,
     pub message: Option<&'a str>,
-    pub date: Option<i64>,
-    pub date_printed: Option<i64>,
+    pub date: Option<isize>,
+    pub date_printed: Option<isize>,
     pub tags: Option<&'a [&'a str]>,
 }
 


### PR DESCRIPTION
There isn't really a good reason to keep date as `i64` since Weechat uses `time_t` which is platform dependent (`i32`/`i64`), so internally storing it as `isize` makes much more sense.