### PR TITLE
fix: preserve integer option string values

### DIFF
--- a/crates/weechat/src/config/section.rs
+++ b/crates/weechat/src/config/section.rs
@@ -595,6 +595,8 @@ impl ConfigSection {
                 description: &settings.description,
                 min: settings.min,
                 max: settings.max,
+                #[cfg(weechat410)]
+                string_values: &settings.string_values,
                 default_value: &settings.default_value.to_string(),
                 value: &settings.default_value.to_string(),
                 ..Default::default()


### PR DESCRIPTION
This fixes a small rust-weechat config bug I hit while making weechat-matrix-rs build with newer WeeChat APIs.

`IntegerOptionSettings` already has `string_values` for WeeChat 4.1+, but `new_integer_option` was not passing them into `OptionDescription`. This keeps symbolic integer values such as `merge-without-core` / `independent` working for downstream config options.

Checked with `cargo check` and `cargo test`.

Fix requested by @strk.
