### PR TITLE
build: track weechat header inputs

### DIFF
--- a/crates/weechat-sys/README.md
+++ b/crates/weechat-sys/README.md
@@ -16,5 +16,8 @@ A custom include file can be set with the `WEECHAT_PLUGIN_FILE` environment
 variable, this environment variable takes a full path to the custom include
 file.
 
+Cargo will rebuild the bindings when these environment variables change or when
+bindgen sees one of the selected header files change.
+
 [Weechat]: weechat.org/
 [API]: https://weechat.org/files/doc/stable/weechat_plugin_api.en.html

--- a/crates/weechat-sys/build.rs
+++ b/crates/weechat-sys/build.rs
@@ -25,7 +25,8 @@ fn build(file: &str) -> Result<Bindings, BindgenError> {
         "WEECHAT_HOOK_SIGNAL_INT",
         "WEECHAT_HOOK_SIGNAL_POINTER",
     ];
-    let mut builder = bindgen::Builder::default();
+    let mut builder =
+        bindgen::Builder::default().parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
 
     builder = builder.header(file);
 


### PR DESCRIPTION
Bindgen now tells Cargo which WeeChat headers it read while generating `weechat-sys` bindings.

That means changing `WEECHAT_PLUGIN_FILE` was already tracked, and now changing the selected header contents is tracked too. Downstream builds should not need `make clean` just to pick up header changes.

Checked with `cargo fmt --check`, `cargo check -p weechat-sys`, and a `touch crates/weechat-sys/src/wrapper.h` smoke that made Cargo report `Dirty weechat-sys`.

Fix requested by @strk.